### PR TITLE
Add zero-shot model integration to evaluation pipeline 

### DIFF
--- a/configs/model/zero-shot.yaml
+++ b/configs/model/zero-shot.yaml
@@ -1,0 +1,3 @@
+model_id: "zero-shot"
+model_kwargs:
+  hypothesis_template: "This text is about {}."

--- a/configs/training/zero_shot.yaml
+++ b/configs/training/zero_shot.yaml
@@ -1,0 +1,6 @@
+model_config: zero-shot
+hparams_config: default
+
+# Only one model needs to be trained per unique train set, which is specified
+# by all the parameters in the data config excluding test_imbalance.
+data_config: football_one_vs_all_balanced

--- a/scripts/experiments/sample.py
+++ b/scripts/experiments/sample.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "data_config",
-        help="path to the data config file specifying the test set to use",
+        help="path to g data config file specifying the test set to use",
     )
     parser.add_argument(
         "train_config",


### PR DESCRIPTION
This pull request introduces support for zero-shot classification using the `transformers` library. It includes updates to configuration files, the addition of a new prediction method, and integration of zero-shot logic into the existing prediction pipeline.

### Zero-shot classification support:

* Added a new configuration file `configs/model/zero-shot.yaml` with `model_id` set to `"zero-shot"` and a customizable `hypothesis_template` for zero-shot classification.
* Updated `configs/training/zero_shot.yaml` to include the new `zero-shot` model configuration and specify a balanced dataset for training.
* Introduced a new method, `get_zero_shot_preds`, in `src/arc_tigers/sampling/utils.py` to compute predictions using a zero-shot classification pipeline. This method uses the `facebook/bart-large-mnli` model and ensures consistent prediction output formatting.

### Pipeline integration:

* Modified the `get_preds` function in `src/arc_tigers/sampling/utils.py` to route predictions to `get_zero_shot_preds` when the `model_id` is `"zero-shot"`.
* Added the `pipeline` import in `src/arc_tigers/sampling/utils.py` to enable the use of the `transformers` library's zero-shot classification functionality.